### PR TITLE
Update compat for PlutoSliderServer to 1.0.0

### DIFF
--- a/.github/workflows/ExportPluto.yaml
+++ b/.github/workflows/ExportPluto.yaml
@@ -21,10 +21,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout this repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install Julia
-              uses: julia-actions/setup-julia@v1
+              uses: julia-actions/setup-julia@v2
               with:
                   version: "1.10" # This will automatically pick the latest Julia version
 
@@ -35,7 +35,7 @@ jobs:
 
             # We set up a folder that Pluto can use to cache exported notebooks. If the notebook file did not change, then Pluto can take the exported file from cache instead of running the notebook.
             - name: Set up notebook state cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: pluto_state_cache
                   key: ${{ runner.os }}-pluto_state_cache-v2-${{ hashFiles('**/Project.toml', '**/Manifest.toml', '.github/workflows/*' ) }}-${{ hashFiles('**/*jl') }}
@@ -48,7 +48,7 @@ jobs:
                 julia -e 'using Pkg
                   Pkg.activate(mktempdir())
                   Pkg.add([
-                    Pkg.PackageSpec(name="PlutoSliderServer", version="0.3.2-0.3"),
+                    Pkg.PackageSpec(name="PlutoSliderServer", version="1"),
                   ])
 
                   import PlutoSliderServer


### PR DESCRIPTION
Hi! This is an automatic PR to update the PlutoSliderServer compat from 0.3 to 1.0.0! I did not test this PR, but PlutoSliderServer 1.0.0 had no breaking changes, except the new Julia 1.10 minimum ([release notes](https://github.com/JuliaPluto/PlutoSliderServer.jl/releases/tag/v1.0.0)).

This might also resolve https://github.com/TidierOrg/TidierCourse/commit/dd0dd180b2a6e8353c6667643c0b0b4ac3ace56f so you don't need the downgrade anymore.